### PR TITLE
documentation/Clarify_access_in_case_of_is-local

### DIFF
--- a/doc/dialects/exasol.md
+++ b/doc/dialects/exasol.md
@@ -101,7 +101,9 @@ The parameter `IS_LOCAL` provides an additional speed-up in this particular use 
 The way this works is that Virtual Schema generates a regular `SELECT` statement instead of an `IMPORT` statement. 
 And that `SELECT` can be directly executed by the core database, whereas the `IMPORT` statement takes a detour via the ExaLoader.
 
-**Important:** Please note that since the generated `SELECT` command runs with the permissions of the owner of the Virtual Schema, that user must have privileges to access what you plan to select! This is *different* from using a connection definition where you can use a different user in that connection.
+**Important:** Please note that since the generated `SELECT` command runs with the permissions of the owner of the Virtual Schema, that user must have privileges to access what you plan to select!
+
+`IMPORT` statements use a connection definition which allows connecting with a different user account. Generated `SELECT` statements do not open additional connections (hence the "local" moniker) so they inherit the context of the Virtual Schema query they are executed in &mdash; including permissions.
 
 #### Data Source is an Exasol Instance or Cluster Only Reachable via JDBC
 

--- a/doc/dialects/exasol.md
+++ b/doc/dialects/exasol.md
@@ -101,6 +101,8 @@ The parameter `IS_LOCAL` provides an additional speed-up in this particular use 
 The way this works is that Virtual Schema generates a regular `SELECT` statement instead of an `IMPORT` statement. 
 And that `SELECT` can be directly executed by the core database, whereas the `IMPORT` statement takes a detour via the ExaLoader.
 
+**Important:** Please note that since the generated `SELECT` command runs with the permissions of the owner of the Virtual Schema, that user must have privileges to access what you plan to select! This is *different* from using a connection definition where you can use a different user in that connection.
+
 #### Data Source is an Exasol Instance or Cluster Only Reachable via JDBC
 
 While this connection type works, it is also the slowest option and exists mainly to support integration tests on the ExaLoader. 


### PR DESCRIPTION
The consequences of using `is-local` are not trivial to understand. This change aims to improve the documentation for more clarity.